### PR TITLE
Bump GitHub Actions to node24 runtimes (DEV-6381)

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -26,7 +26,7 @@ jobs:
           echo "PR Title: ${{ inputs.TITLE }}"
           
       - name: Approve PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.IS_CICD_GITHUB_ACTION_TOKEN }}
           script: |
@@ -40,7 +40,7 @@ jobs:
             console.log('PR approved successfully');
             
       - name: Merge PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.IS_CICD_GITHUB_ACTION_TOKEN }}
           script: |
@@ -56,7 +56,7 @@ jobs:
             
       - name: Comment on merged PR
         if: success()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.IS_CICD_GITHUB_ACTION_TOKEN }}
           script: |

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -35,21 +35,21 @@ jobs:
       digest: ${{ steps.docker_build.outputs.digest }}
     steps:
       - name: Check Out Repo 
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{ inputs.registry }}
           username: ${{ secrets.IS_DOCKER_HUB_USERNAME }}
           password: ${{ secrets.IS_DOCKER_HUB_PASSWORD }}
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -38,9 +38,6 @@ jobs:
       - uses: actions/checkout@v5
       - name: golangci-lint (v1)
         if: startsWith(inputs.GOLANGCI_LINT_VERSION, 'v1')
-        # node20: v6 is the last golangci-lint-action major that supports golangci-lint
-        # v1.x. Moving to a node24 action (v9) requires migrating consumers to golangci-lint
-        # v2 config, so this branch still emits the Node.js deprecation warning. See DEV-6381.
         uses: golangci/golangci-lint-action@v6
         with:
           version: ${{ inputs.GOLANGCI_LINT_VERSION }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -32,19 +32,22 @@ jobs:
         run: |
           git config --global url."https://${USERNAME}:${TOKEN}@github.com".insteadOf "https://github.com" && \
           export GOPRIVATE="github.com/expedient"
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.GO_VERSION }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: golangci-lint (v1)
         if: startsWith(inputs.GOLANGCI_LINT_VERSION, 'v1')
+        # node20: v6 is the last golangci-lint-action major that supports golangci-lint
+        # v1.x. Moving to a node24 action (v9) requires migrating consumers to golangci-lint
+        # v2 config, so this branch still emits the Node.js deprecation warning. See DEV-6381.
         uses: golangci/golangci-lint-action@v6
         with:
           version: ${{ inputs.GOLANGCI_LINT_VERSION }}
           args: --timeout=${{ inputs.GOLANGCI_LINT_TIMEOUT }}
       - name: golangci-lint (v2)
         if: startsWith(inputs.GOLANGCI_LINT_VERSION, 'v2')
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: ${{ inputs.GOLANGCI_LINT_VERSION }}
           args: --timeout=${{ inputs.GOLANGCI_LINT_TIMEOUT }}

--- a/.github/workflows/kustomize-deploy-commit.yml
+++ b/.github/workflows/kustomize-deploy-commit.yml
@@ -55,7 +55,7 @@ jobs:
     name: kustomize-deploy-commit
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: ${{ inputs.KUBERNETES_REPO }}
           fetch-depth: 0

--- a/.github/workflows/newman-k8s-tests.yml
+++ b/.github/workflows/newman-k8s-tests.yml
@@ -77,17 +77,17 @@ jobs:
     runs-on: ubuntu-24.04
     name: Functional Tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           path: ${{inputs.APPLICATION}}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           repository: ${{inputs.KUBERNETES_REPO}}
           ref: ${{inputs.KUBERNETES_REPO_REF}}
           token: ${{secrets.IS_CICD_GITHUB_ACTION_TOKEN}}
           path: kubernetes
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.9.0
+        uses: helm/kind-action@v1.14.0
       - name: Check kind
         run: |
           kubectl cluster-info
@@ -119,6 +119,8 @@ jobs:
         run: |
           kubectl logs deploy/${{inputs.APPLICATION_PREFIX}}${{inputs.APPLICATION}} --all-containers
       - name: Setup debug session on failure
+        # node16: no node20+ upstream release — still emits the Node.js deprecation
+        # warning, but only runs on failure when debugging is enabled. See DEV-6381.
         uses: lhotari/action-upterm@v1
         if: failure() && inputs.ENABLE_DEBUG_ON_FAILURE
         with:

--- a/.github/workflows/newman-k8s-tests.yml
+++ b/.github/workflows/newman-k8s-tests.yml
@@ -119,8 +119,6 @@ jobs:
         run: |
           kubectl logs deploy/${{inputs.APPLICATION_PREFIX}}${{inputs.APPLICATION}} --all-containers
       - name: Setup debug session on failure
-        # node16: no node20+ upstream release — still emits the Node.js deprecation
-        # warning, but only runs on failure when debugging is enabled. See DEV-6381.
         uses: lhotari/action-upterm@v1
         if: failure() && inputs.ENABLE_DEBUG_ON_FAILURE
         with:

--- a/.github/workflows/postman-k8s-contract-tests.yml
+++ b/.github/workflows/postman-k8s-contract-tests.yml
@@ -100,8 +100,6 @@ jobs:
         run: |
           kubectl logs deploy/${{inputs.APPLICATION}} --all-containers
       - name: Setup debug session on failure
-        # node16: no node20+ upstream release — still emits the Node.js deprecation
-        # warning, but only runs on failure when debugging is enabled. See DEV-6381.
         uses: lhotari/action-upterm@v1
         if: failure() && inputs.ENABLE_DEBUG_ON_FAILURE
         with:

--- a/.github/workflows/postman-k8s-contract-tests.yml
+++ b/.github/workflows/postman-k8s-contract-tests.yml
@@ -58,17 +58,17 @@ jobs:
     runs-on: ubuntu-24.04
     name: Contract Tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           path: ${{inputs.APPLICATION}}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           repository: ${{inputs.KUBERNETES_REPO}}
           ref: ${{inputs.KUBERNETES_REPO_REF}}
           token: ${{secrets.IS_CICD_GITHUB_ACTION_TOKEN}}
           path: kubernetes
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.9.0
+        uses: helm/kind-action@v1.14.0
       - name: Check kind
         run: |
           kubectl cluster-info
@@ -100,6 +100,8 @@ jobs:
         run: |
           kubectl logs deploy/${{inputs.APPLICATION}} --all-containers
       - name: Setup debug session on failure
+        # node16: no node20+ upstream release — still emits the Node.js deprecation
+        # warning, but only runs on failure when debugging is enabled. See DEV-6381.
         uses: lhotari/action-upterm@v1
         if: failure() && inputs.ENABLE_DEBUG_ON_FAILURE
         with:

--- a/.github/workflows/postman-k8s-tests.yml
+++ b/.github/workflows/postman-k8s-tests.yml
@@ -92,17 +92,17 @@ jobs:
     runs-on: ubuntu-24.04
     name: Functional Tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           path: ${{inputs.APPLICATION}}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           repository: ${{inputs.KUBERNETES_REPO}}
           ref: ${{inputs.KUBERNETES_REPO_REF}}
           token: ${{secrets.IS_CICD_GITHUB_ACTION_TOKEN}}
           path: kubernetes
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.9.0
+        uses: helm/kind-action@v1.14.0
       - name: Check kind
         run: |
           kubectl cluster-info
@@ -134,6 +134,8 @@ jobs:
         run: |
           kubectl logs deploy/${{inputs.APPLICATION_PREFIX}}${{inputs.APPLICATION}} --all-containers
       - name: Setup debug session on failure
+        # node16: no node20+ upstream release — still emits the Node.js deprecation
+        # warning, but only runs on failure when debugging is enabled. See DEV-6381.
         uses: lhotari/action-upterm@v1
         if: failure() && inputs.ENABLE_DEBUG_ON_FAILURE
         with:

--- a/.github/workflows/postman-k8s-tests.yml
+++ b/.github/workflows/postman-k8s-tests.yml
@@ -134,8 +134,6 @@ jobs:
         run: |
           kubectl logs deploy/${{inputs.APPLICATION_PREFIX}}${{inputs.APPLICATION}} --all-containers
       - name: Setup debug session on failure
-        # node16: no node20+ upstream release — still emits the Node.js deprecation
-        # warning, but only runs on failure when debugging is enabled. See DEV-6381.
         uses: lhotari/action-upterm@v1
         if: failure() && inputs.ENABLE_DEBUG_ON_FAILURE
         with:

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -19,7 +19,7 @@ jobs:
     name: Slack Notification
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Slack Notification
       uses: rtCamp/action-slack-notify@v2
       env:

--- a/.github/workflows/sync-postman-collection.yml
+++ b/.github/workflows/sync-postman-collection.yml
@@ -17,8 +17,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v5
     - name: Sync
-      # node12: unmaintained, no node20+ upstream release — still emits the Node.js
-      # deprecation warning. Needs replacement with a maintained action. See DEV-6381.
       uses: jneate/postman-collection-action@v1
       with:
         postmanApiKey: ${{ secrets.POSTMAN_API_KEY }}

--- a/.github/workflows/sync-postman-collection.yml
+++ b/.github/workflows/sync-postman-collection.yml
@@ -15,8 +15,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
     - name: Sync
+      # node12: unmaintained, no node20+ upstream release — still emits the Node.js
+      # deprecation warning. Needs replacement with a maintained action. See DEV-6381.
       uses: jneate/postman-collection-action@v1
       with:
         postmanApiKey: ${{ secrets.POSTMAN_API_KEY }}


### PR DESCRIPTION
## What

Bumps the GitHub Actions in every reusable workflow to versions that run on the **Node.js 24** runtime, clearing the `Node.js 20 is deprecated` warning seen across all consuming repos (email-gateway, hopper, umbra, …).

GitHub removed the node20 runtime from runners ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)); actions declaring `using: node20` are currently force-run on node24 and warn, and will **break** once node20 support is fully dropped. This is proactive maintenance.

Consumer repos pin these workflows with `@main`, so merging this propagates the fix to every consumer on its next run — no release tag bump or per-consumer PRs needed.

Jira: **DEV-6381**

## Upgrade map (all targets verified `using: node24`)

| File | Change |
|---|---|
| `docker-build-and-push.yml` | checkout `v3→v5`, docker/login-action `v2→v4`, docker/setup-buildx-action `v2→v4`, docker/build-push-action `v4→v7` |
| `kustomize-deploy-commit.yml` | checkout `v3→v5` |
| `slack-notify.yml` | checkout `v3→v5` |
| `sync-postman-collection.yml` | checkout `v2→v5` |
| `auto-merge-dependabot.yml` | actions/github-script `v6→v8` (×3) |
| `newman-k8s-tests.yml` | checkout `v3→v5` (×2), helm/kind-action `v1.9.0→v1.14.0` |
| `postman-k8s-tests.yml` | checkout `v3→v5` (×2), helm/kind-action `v1.9.0→v1.14.0` |
| `postman-k8s-contract-tests.yml` | checkout `v3→v5` (×2), helm/kind-action `v1.9.0→v1.14.0` |
| `golangci-lint.yml` | setup-go `v5→v6`, checkout `v3→v5`, golangci-lint-action `v7→v9` (golangci-lint v2 branch only) |

## Known remaining warnings (no node24 upstream release — follow-up)

Left in place with an inline explanatory comment; documented in DEV-6381:

- **golangci-lint-action@v6** on the golangci-lint **v1** branch — v6 is the last major supporting golangci-lint v1.x. Reaching node24 (action v9) requires migrating consumers to golangci-lint **v2** config. The default `GOLANGCI_LINT_VERSION` is `v1.64.6`, so most repos still hit this branch.
- **lhotari/action-upterm@v1** (node16) — debug-SSH-on-failure action; no node20+ release upstream. Only runs on failure when debugging is enabled.
- **jneate/postman-collection-action@v1** (node12) — unmaintained; needs replacement.

## Risk

Only non-mechanical bump is `golangci-lint-action@v7→v9`, which requires golangci-lint v2.x — already guaranteed by that conditional branch (`if: startsWith(GOLANGCI_LINT_VERSION, 'v2')`). The `version` + `args` inputs used here remain supported.

## Verification

- `actionlint` passes clean on all 9 workflow files.
- End-to-end: after merge, trigger a build in a consumer repo (e.g. hopper `pr-validation`) and confirm the deprecation annotation no longer lists checkout/docker/github-script/setup-go/kind-action. Residual warnings expected only for the three documented actions above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
