### PR TITLE
Default golangci-lint version to v2.11.4 (DEV-6381)

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,7 +6,11 @@ on:
         default: '1.22'
         type: string
       GOLANGCI_LINT_VERSION:
-        default: 'v1.64.6'
+        # Default to golangci-lint v2 so unpinned consumers run on the v2 code path
+        # (golangci-lint-action@v9, Node.js 24). Repos that need a different version
+        # can still override this input. NOTE: consumers must be on a v2-format
+        # .golangci.yaml before relying on this default. See DEV-6381.
+        default: 'v2.11.4'
         type: string
       GOLANGCI_LINT_TIMEOUT:
         default: '3m'


### PR DESCRIPTION
## What

Changes the `golangci-lint.yml` reusable workflow's default `GOLANGCI_LINT_VERSION` from `v1.64.6` → `v2.11.4`, so **unpinned consumers run on the v2 code path** (`golangci/golangci-lint-action@v9`, Node.js 24) instead of the v1 path (`@v6`, Node.js 20).

Stacked on #44 (which bumps the v2 branch's action to @v9).

## Why

Follow-up to **DEV-6381**. With the old `v1.64.6` default, any repo that doesn't pin a version falls onto the v1 branch and keeps emitting the `Node.js 20 is deprecated` warning. Centralizing the version here means ancillary repos don't each carry a pin that rots — they inherit whatever this default is, bumped in one place.

## Merge order — this PR goes BEFORE the consumer config PRs

Correct sequence:

1. **#44** (node24 action bumps) → merge to `main`.
2. **This PR (#45)** → merge to `main`. Now `golangci-lint.yml@main` defaults to golangci-lint **v2** on `golangci-lint-action@v9` (Node 24).
3. **The six unpinned consumer config PRs** (below) → merge, in any order.

**Why this order and not the reverse:** the six consumer PRs are unpinned and carry a **v2-format** `.golangci.yaml`. Until this PR is on `main`, those repos resolve the old `v1.64.6` default — a **v1 linter reads a v2 config and errors**, so their PR checks stay **red and they cannot merge**. This PR must land first to turn them green. (So the earlier "config PRs first" note was backwards — it's impossible.)

**Transient window:** once this merges, each unpinned consumer's `main` is briefly mismatched (v2 default vs. its not-yet-updated config) until its config PR merges. Those repos are dormant, so nothing runs their `main` CI in the gap — merge the six promptly and it closes. Repos that pin a version (**hopper**, **is-auth**) already run v2 and are unaffected.

### The six consumer config PRs (all unpinned)

| Repo | Config PR | Notes |
|---|---|---|
| email-gateway | Expedient/email-gateway#238 | migrated |
| billing-service | Expedient/billing-service#216 | migrated (+ST1008 excl.) |
| hopper-go-client | Expedient/hopper-go-client#22 | migrated (+QF1012 excl.) |
| commander | Expedient/commander#51 | minimal config added |
| is-codegen | Expedient/is-codegen#40 | minimal config added |
| legacy-smc-tests | Expedient/legacy-smc-tests#9 | migrated (+ST1008 excl.) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
