### PR TITLE
DEV-6484: disable provenance/SBOM attestations on ghcr push

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -54,6 +54,8 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: true
+          provenance: false
+          sbom: false
           tags: ${{ inputs.tags }}
           build-args: ${{ secrets.build_args }}
       - name: Image digest


### PR DESCRIPTION
## What

Add `provenance: false` and `sbom: false` to the `docker/build-push-action` step in the shared `docker-build-and-push.yml` reusable workflow.

## Why

`build-push-action` emits SLSA provenance + SBOM attestations by default. That pushes an extra **attestation manifest + manifest list** per build — roughly **2x** the manifest/blob PUTs to ghcr. Nothing in our pipeline consumes these attestations, and images are deployed by digest, so they're pure overhead.

This is **Phase 1** (safe mitigation) for **DEV-6484** — ghcr push intermittently 403s on a GitHub *secondary rate limit*. All ~13 is-dev repos push under the same shared `expedient-is-dev` PAT identity, so they share one per-account rate-limit bucket; cutting per-push request volume in half reduces how often that bucket trips.

## Blast radius

Reusable workflow consumed by ~13 repos (hopper, is-auth, billing-service, cadence, lumen, SMC, dns-api, commander, email-gateway, sieve, shift-report, facility-tracker). Change is low-risk: it only removes attestation artifacts; the deployed image manifest + digest are unchanged.

## Follow-up (not in this PR)

**Phase 2**: switch the ghcr **push login** from the shared PAT to each repo's own `GITHUB_TOKEN` (`permissions: packages: write` + per-package Actions access grant) so repos get separate rate-limit buckets. The `build_args` PAT stays (needed for cross-repo private Go module fetch, e.g. `github.com/expedient/sieve`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
