### PR TITLE
DEV-6484: opt-in GITHUB_TOKEN auth for registry push

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -15,11 +15,16 @@ on:
         required: false
         default: "docker.io"
         type: string
+      use_github_token_auth:
+        description: "Authenticate to the registry with the per-repo GITHUB_TOKEN instead of IS_DOCKER_HUB_* creds. Requires 'packages: write' on the calling job. Use for ghcr.io."
+        required: false
+        default: false
+        type: boolean
     secrets:
       IS_DOCKER_HUB_USERNAME:
-        required: true
+        required: false
       IS_DOCKER_HUB_PASSWORD:
-        required: true
+        required: false
       build_args:
         required: false
     outputs:
@@ -38,12 +43,12 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Login to Docker Hub
+      - name: Login to registry
         uses: docker/login-action@v4
         with:
           registry: ${{ inputs.registry }}
-          username: ${{ secrets.IS_DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.IS_DOCKER_HUB_PASSWORD }}
+          username: ${{ inputs.use_github_token_auth && github.actor || secrets.IS_DOCKER_HUB_USERNAME }}
+          password: ${{ inputs.use_github_token_auth && github.token || secrets.IS_DOCKER_HUB_PASSWORD }}
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## What

Add an opt-in `use_github_token_auth` input to the shared `docker-build-and-push.yml` reusable workflow. When `true`, the registry login authenticates with the caller's per-repo `GITHUB_TOKEN` (`github.actor` / `github.token`) instead of the shared `IS_DOCKER_HUB_*` creds. Also relaxes `IS_DOCKER_HUB_USERNAME`/`IS_DOCKER_HUB_PASSWORD` to optional so token-auth callers need not pass them.

```yaml
username: ${{ inputs.use_github_token_auth && github.actor || secrets.IS_DOCKER_HUB_USERNAME }}
password: ${{ inputs.use_github_token_auth && github.token   || secrets.IS_DOCKER_HUB_PASSWORD }}
```

## Why

**Phase 2** of **DEV-6484**. ghcr push intermittently 403s on a GitHub *secondary rate limit*. hopper pushes to ghcr under the shared `expedient-is-dev` PAT, which is also the org's identity for lots of other GitHub automation (private Go module clones, kustomize deploy commits, coverage pushes) — so hopper's push competes against all of it in one per-account bucket.

`umbra` already pushes to ghcr with `${{ github.token }}` and pushed successfully in the same minute hopper's PAT push was rate-limited. This input lets hopper (and any future ghcr caller, e.g. lumen) do the same: push under its own per-repo identity with a separate rate-limit bucket.

## Compatibility

- **Default is `false`** → every existing Docker Hub caller (cadence, SMC, is-auth, billing-service, dns-api, commander, email-gateway, …) is unchanged.
- A caller opting in must set `permissions: { packages: write }` on the job **and** grant its repo Write access to the target ghcr package. Otherwise the push 403s.

## Rollout order

Merge this **first**, then the hopper opt-in PR (which passes `use_github_token_auth: true`). The hopper PR's CI stays red until this input exists on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
